### PR TITLE
Try fixing deprecation warning on libjson 1.8.4 while using Json::Reader

### DIFF
--- a/IEX.h
+++ b/IEX.h
@@ -64,7 +64,7 @@ namespace IEX {
             curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
             long int httpCode(0);
 
-            std::stringstream httpData;
+            std::unique_ptr<std::string> httpData(new std::string);
 
             curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, callback);
             curl_easy_setopt(curl, CURLOPT_WRITEDATA, httpData.get());
@@ -72,10 +72,9 @@ namespace IEX {
             curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &httpCode);
             curl_easy_cleanup(curl);
 
-            Json::CharReaderBuilder jsonReader;
-            std::string errs;
-
-            Json::parseFromStream(jsonReader, httpData, &jsonData, &errs);
+            std::stringstream ss;
+            ss.str(*httpData);
+            ss >> jsonData;
         }
 
         struct KeyStatsData {

--- a/IEX.h
+++ b/IEX.h
@@ -6,6 +6,7 @@
 #include <curl/curl.h>
 #include <cstdint>  // uint64_t, etc.
 #include <iostream>
+#include <sstream>
 #include <locale>  // std::locale, std::isdigit
 #include <memory>  // std::unique_ptr
 #include <string>
@@ -62,18 +63,19 @@ namespace IEX {
             curl_easy_setopt(curl, CURLOPT_TIMEOUT, 10);
             curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
             long int httpCode(0);
-            std::unique_ptr<std::string> httpData(new std::string());
+
+            std::stringstream httpData;
+
             curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, callback);
             curl_easy_setopt(curl, CURLOPT_WRITEDATA, httpData.get());
             curl_easy_perform(curl);
             curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &httpCode);
             curl_easy_cleanup(curl);
 
-            // Json::CharReaderBuilder jsonReader;
-            // Json::CharReader* reader;
+            Json::CharReaderBuilder jsonReader;
+            std::string errs;
 
-            Json::Reader jsonReader;
-            jsonReader.parse(*httpData, jsonData);
+            Json::parseFromStream(jsonReader, httpData, &jsonData, &errs);
         }
 
         struct KeyStatsData {


### PR DESCRIPTION
**Scenario**: MacOS and libjson installed via homebrew.

```
./compile.sh
Starting compilation
Done

./main AMZN
[1]    45387 segmentation fault  ./main AMZN
```

---

`brew list --versions jsoncpp`

```
jsoncpp 1.8.4
```
---
There is no deprecation warnings on my Linux. This is the version running there:

```
dpkg -s libjsoncpp-dev | grep Version
Version: 1.7.4-3
```